### PR TITLE
Segundo intento de configurar Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "4.8.0"
+script:
+  - npm test


### PR DESCRIPTION
En el intento anterior ya estaba el .travis.yml, pero solo aparecía el cartel de "aceptar pull request", sin el que indicaba si los tests pasaban o no.